### PR TITLE
Changed Date format to use timezone abbreviation

### DIFF
--- a/index.php
+++ b/index.php
@@ -100,7 +100,7 @@ endif;
 /**
  * Format date according to RFC 822
  */
-$date_fmt = 'D, d M Y H:i:s e';
+$date_fmt = 'D, d M Y H:i:s T';
 
 /**
  * Check for HTTPS


### PR DESCRIPTION
RFC 822 requires timezone to be displayed as abbreviation or offset from GMT. 

in PHP e will display the abbreviation OR the long description, depending on the timezone. T will always display the abbreviation.