### PR TITLE
Fixed atom:link

### DIFF
--- a/index.php
+++ b/index.php
@@ -134,7 +134,7 @@ $channel->addChild('link', $conf['link']);
 $channel->addChild('description', $conf['description']);
 $channel->addChild('pubDate', date($date_fmt));
 $channel->addChild('lastBuildDate', date($date_fmt));
-$atomlink = $channel->addChild('atom:link');
+$atomlink = $channel->addChild('atom:atom:link');
 $atomlink->addAttribute('rel', 'self');
 $atomlink->addAttribute('type', 'application/rss+xml');
 if (isset($castimg_url)) :


### PR DESCRIPTION
In the original code the output from the atom:link block was <link> instead of <atom:link> This resulted in a feed that wouldn't pass w3c validation. 

I updated the relevant block to ensure that <atom:link> would be output instead.