### PR TITLE
Allow specifying a custom subdirectory for audio files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ config.php
 ffmpeg
 tmp
 !/assets/*
+/media/*

--- a/config.php.default
+++ b/config.php.default
@@ -15,6 +15,12 @@
  *****************************************************************************/
 
 /**
+ * The base path to scan for media items
+ * This is relative to the current script
+ */
+$media_base_path = 'media';
+
+/**
  * Whether to check for mediainfo
  */
 $mediainfo_check = false;


### PR DESCRIPTION
This lets users set a separate subdirectory to store audio files in. The default behavior of using the current directory is unchanged.