### PR TITLE
Support etags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ config.php
 ffmpeg
 tmp
 !/assets/*
+/media/*

--- a/config.php.default
+++ b/config.php.default
@@ -15,6 +15,12 @@
  *****************************************************************************/
 
 /**
+ * The base path to scan for media items
+ * This is relative to the current script
+ */
+$media_base_path = 'media';
+
+/**
  * Whether to check for mediainfo
  */
 $mediainfo_check = false;

--- a/index.php
+++ b/index.php
@@ -86,6 +86,32 @@ endif;
 header('Content-type: application/rss+xml; charset=utf-8');
 
 /**
+ * Calculate the etag and compare
+ */
+$etag_hash = hash_init("sha256");
+if ($handle = opendir($media_base_path)) :
+    while ($files[] = readdir($handle));
+    sort($files);
+
+    foreach ($files as $entry) :
+        $entry_path = $media_base_path . "/" . $entry;
+        if (array_key_exists(pathinfo($entry_path, PATHINFO_EXTENSION), $exts) && !preg_match('/^\./', $entry)) :
+            $mtime = (string)filemtime($entry_path);
+            hash_update($etag_hash, $mtime);
+        endif;
+    endforeach;
+    closedir($handle);
+endif;
+$etag = hash_final($etag_hash);
+
+if (trim($_SERVER['HTTP_IF_NONE_MATCH']) == $etag) :
+    header("HTTP/1.1 304 Not Modified");
+    exit;
+endif;
+
+header("ETag: $etag");
+
+/**
  * Get mediainfo path
  */
 $mediainfo = '';


### PR DESCRIPTION
ETags help clients (and podcast fetching servers) avoid re-fetching an entire feed if none of the contents have changed.

This commit depends on pull request #6 